### PR TITLE
[Bug 1007034]

### DIFF
--- a/dom/indexedDB/ActorsParent.cpp
+++ b/dom/indexedDB/ActorsParent.cpp
@@ -1296,17 +1296,17 @@ UpgradeSchemaFrom4To5(mozIStorageConnection* aConnection)
   {
     mozStorageStatementScoper scoper(stmt);
 
-    rv = stmt->BindStringParameter(0, name);
+    rv = stmt->BindStringByIndex(0, name);
     if (NS_WARN_IF(NS_FAILED(rv))) {
       return rv;
     }
 
-    rv = stmt->BindInt32Parameter(1, intVersion);
+    rv = stmt->BindInt32ByIndex(1, intVersion);
     if (NS_WARN_IF(NS_FAILED(rv))) {
       return rv;
     }
 
-    rv = stmt->BindInt64Parameter(2, dataVersion);
+    rv = stmt->BindInt64ByIndex(2, dataVersion);
     if (NS_WARN_IF(NS_FAILED(rv))) {
       return rv;
     }

--- a/storage/StorageBaseStatementInternal.h
+++ b/storage/StorageBaseStatementInternal.h
@@ -10,6 +10,7 @@
 #include "nsISupports.h"
 #include "nsCOMPtr.h"
 #include "nsAutoPtr.h"
+#include "mozStorageHelper.h"
 
 struct sqlite3;
 struct sqlite3_stmt;
@@ -236,6 +237,7 @@ NS_DEFINE_STATIC_IID_ACCESSOR(StorageBaseStatementInternal,
   }                                                                           \
   NS_IMETHODIMP _class::BIND_NAME_CONCAT(_name, Parameter) _declIndex         \
   {                                                                           \
+    WARN_DEPRECATED();
     _guard                                                                    \
     mozIStorageBindingParams *params = getParams();                           \
     NS_ENSURE_TRUE(params, NS_ERROR_OUT_OF_MEMORY);                           \


### PR DESCRIPTION
1) Added console warnings for the deprecated BindXXXParameter methods in mozIStorageBaseStatement.

2) Replaced calls to the above deprecated methods in dom/indexedDB/ActorsParent.cpp.